### PR TITLE
upgrade auto release actions versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,7 @@ jobs:
           - 'il-central-1'
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Artifact for Lambdas
         uses: actions/download-artifact@v4
@@ -114,7 +114,7 @@ jobs:
           path: .
 
       - name: Configure AWS CLI
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,26 +10,26 @@ jobs:
     steps:
       # Check out the repository to the runner
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Fetch all history for all tags and branches
       - run: git fetch --prune --unshallow
 
       # Setup Go environment
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
+          go-version: '1.22.2'
 
       # Import GPG key for GoReleaser
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --clean
@@ -54,7 +54,7 @@ jobs:
           cd ..
 
       - name: Upload Lambdas ZIP as Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: lambdas
           path: |
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Artifact for Lambdas
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: lambdas
           path: .


### PR DESCRIPTION
- `actions/checkout@v3` >> `actions/checkout@v4`
- `actions/setup-go@v3` >> `actions/setup-go@v5`
- go version `1.19` >> go version `1.22.2`
- `crazy-max/ghaction-import-gpg@v4` >> `crazy-max/ghaction-import-gpg@v6`
- `goreleaser/goreleaser-action@v4` >> `goreleaser/goreleaser-action@v5`
- `actions/upload-artifact@v2` >> `actions/upload-artifact@v4`
- `actions/download-artifact@v2` >> `actions/download-artifact@v4`
- `aws-actions/configure-aws-credentials@v1` >> `aws-actions/configure-aws-credentials@v4`