### PR TITLE
[Bug] Make sure log group created EventBridge trigger created when only custom log groups provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+.DS_Store
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Once new logs are added to your chosen log group, they will be sent to your Logz
 > If you've used the `services` field, you'll have to **wait 6 minutes** before creating new log groups for your chosen services. This is due to cold start and custom resource invocation, that can cause the Lambda to behave unexpectedly.
 
 ### Changelog:
+- **0.3.2**:
+  - Fix issue where EventBridge trigger for log group creation was not created when using only `customLogGroups`.
 - **0.3.1**:
     - Support deploying multiple stacks within the same AWS account
     - Resolve bug with update mechanism

--- a/cloudformation/sam-template.yaml
+++ b/cloudformation/sam-template.yaml
@@ -66,10 +66,15 @@ Parameters:
     Default: 5
 
 Conditions:
-  createEventbridgeTrigger: !Not
-    - !Equals
-      - !Ref services
-      - ''
+  createEventbridgeTrigger: !Or
+    - !Not
+      - !Equals
+        - !Ref services
+        - ''
+    - !Not
+      - !Equals
+        - !Ref customLogGroups
+        - ''
   secretChangeEventsEnabled: !Equals
     - !Ref useCustomLogGroupsFromSecret
     - "true"


### PR DESCRIPTION
## Description 

- make sure `createEventbridgeTrigger` condition will be true also if only `customLogGroups` contain values

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
