### PR TITLE
[Bug] fix `logGroupCreated` trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Once new logs are added to your chosen log group, they will be sent to your Logz
 > If you've used the `services` field, you'll have to **wait 6 minutes** before creating new log groups for your chosen services. This is due to cold start and custom resource invocation, that can cause the Lambda to behave unexpectedly.
 
 ### Changelog:
+- **0.3.3**:
+  - Fix issue where EventBridge trigger for log group creation was not created
 - **0.3.2**:
   - Fix issue where EventBridge trigger for log group creation was not created when using only `customLogGroups`.
 - **0.3.1**:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Once new logs are added to your chosen log group, they will be sent to your Logz
 
 ### Changelog:
 - **0.3.3**:
+  - Fix timing issue to make sure bucket is created before the delivery stream
   - Fix issue where EventBridge trigger for log group creation was not created
 - **0.3.2**:
   - Fix issue where EventBridge trigger for log group creation was not created when using only `customLogGroups`.

--- a/cloudformation/sam-template.yaml
+++ b/cloudformation/sam-template.yaml
@@ -226,7 +226,8 @@ Resources:
 
   logGroupCreationEvent:
     Condition: createEventbridgeTrigger
-    Type: AWS::Events::Rule
+    DependsOn: LogGroupEventsLambdaFunction
+    Type: 'AWS::Events::Rule'
     Properties:
       Description: 'This event is triggered by the creation of a new log group, and triggers the Logz.io subscription filter function.'
       EventPattern:
@@ -247,6 +248,7 @@ Resources:
 
   secretChangeEvent:
     Condition: secretChangeEventsEnabled
+    DependsOn: LogGroupEventsLambdaFunction
     Type: 'AWS::Events::Rule'
     Properties:
       Description: 'This event is triggered by change in the secret where the custom log groups are saved (if used a secret)'

--- a/cloudformation/sam-template.yaml
+++ b/cloudformation/sam-template.yaml
@@ -293,6 +293,7 @@ Resources:
   # Firehose and S3 Resources
   logzioFirehose:
     Type: AWS::KinesisFirehose::DeliveryStream
+    DependsOn: logzioS3BackupBucket
     Properties:
       DeliveryStreamName: !Join [ '-', [ 'logzio', !Select [ 4, !Split [ '-', !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ] ] ] ] ]
       DeliveryStreamType: 'DirectPut'


### PR DESCRIPTION
## Description 

- the `logGroupCreated` trigger was not working properly, seems like it was because it was missing `'` around the resource type name
- added on the way `DependsOn` to the relevant triggers for more clarity
- added  `DependsOn` to the delivery stream, to make sure it's not trying to get created before the backup bucket is ready
- updated readme 

I'll open us a ticket to add a test for it in the e2e so we can verify it better in future versions

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
