### PR TITLE
Feat/tag resource

### DIFF
--- a/cloudformation/sam-template.yaml
+++ b/cloudformation/sam-template.yaml
@@ -296,6 +296,68 @@ Resources:
       Principal: 'events.amazonaws.com'
       SourceArn: !GetAtt secretChangeEvent.Arn
 
+  tagLogGroupEvent:
+    Condition: createEventbridgeTrigger
+    DependsOn: LogGroupEventsLambdaFunction
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: 'This event is triggered when a CloudWatch log group is tagged, and triggers the Logz.io subscription filter function.'
+      EventPattern:
+        source:
+          - 'aws.logs'
+        detail-type:
+          - 'AWS API Call via CloudTrail'
+        detail:
+          eventSource:
+            - 'logs.amazonaws.com'
+          eventName:
+            - 'TagResource'
+      Name: !Join [ '-', [ 'logGroupTagged', !Select [ 4, !Split [ '-', !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ] ] ] ] ]
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt LogGroupEventsLambdaFunction.Arn
+          Id: 'TagLogGroupEventsLambdaFunctionTarget'
+
+  tagLambdaEvent:
+    Condition: createEventbridgeTrigger
+    DependsOn: LogGroupEventsLambdaFunction
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: 'This event is triggered when a Lambda function is tagged, and triggers the Logz.io subscription filter function.'
+      EventPattern:
+        source:
+          - 'aws.lambda'
+        detail-type:
+          - 'AWS API Call via CloudTrail'
+        detail:
+          eventSource:
+            - 'lambda.amazonaws.com'
+          eventName:
+            - 'TagResource20170331v2'
+      Name: !Join [ '-', [ 'lambdaTagged', !Select [ 4, !Split [ '-', !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ] ] ] ] ]
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt LogGroupEventsLambdaFunction.Arn
+          Id: 'TagLambdaEventsLambdaFunctionTarget'
+
+  PermissionForTagLogGroupEventToInvokeLambda:
+    Condition: createEventbridgeTrigger
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref LogGroupEventsLambdaFunction
+      Principal: 'events.amazonaws.com'
+      SourceArn: !GetAtt tagLogGroupEvent.Arn
+
+  PermissionForTagLambdaEventToInvokeLambda:
+    Condition: createEventbridgeTrigger
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref LogGroupEventsLambdaFunction
+      Principal: 'events.amazonaws.com'
+      SourceArn: !GetAtt tagLambdaEvent.Arn
+
   # Firehose and S3 Resources
   logzioFirehose:
     Type: AWS::KinesisFirehose::DeliveryStream

--- a/log-group-events-lambda/handler/config.go
+++ b/log-group-events-lambda/handler/config.go
@@ -21,9 +21,22 @@ type Config struct {
 	servicesValue        string
 	filterName           string
 	filterPattern        string
+	monitoringTagKey     string
+	monitoringTagValue   string
 }
 
 func NewConfig() *Config {
+	// Get monitoring tag key and value with defaults
+	monitoringTagKey := os.Getenv(envMonitoringTagKey)
+	if monitoringTagKey == emptyString {
+		monitoringTagKey = defaultMonitoringTagKey
+	}
+
+	monitoringTagValue := os.Getenv(envMonitoringTagValue)
+	if monitoringTagValue == emptyString {
+		monitoringTagValue = defaultMonitoringTagValue
+	}
+
 	c := Config{
 		awsPartition:         os.Getenv(envAwsPartition),
 		destinationArn:       os.Getenv(envFirehoseArn),
@@ -36,6 +49,8 @@ func NewConfig() *Config {
 		servicesValue:        os.Getenv(common.EnvServices),
 		filterName:           os.Getenv(envStackName) + "_" + subscriptionFilterName,
 		filterPattern:        os.Getenv(envFilterPattern),
+		monitoringTagKey:     monitoringTagKey,
+		monitoringTagValue:   monitoringTagValue,
 	}
 
 	err := c.validateRequired()

--- a/log-group-events-lambda/handler/config.go
+++ b/log-group-events-lambda/handler/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	filterPattern        string
 	monitoringTagKey     string
 	monitoringTagValue   string
+	tagEventsEnabled     bool
 }
 
 func NewConfig() *Config {
@@ -35,6 +36,13 @@ func NewConfig() *Config {
 	monitoringTagValue := os.Getenv(envMonitoringTagValue)
 	if monitoringTagValue == emptyString {
 		monitoringTagValue = defaultMonitoringTagValue
+	}
+
+	// Get tag events enabled flag (default: false)
+	tagEventsEnabled := false
+	tagEventsEnabledStr := os.Getenv(envTagEventsEnabled)
+	if tagEventsEnabledStr == "true" || tagEventsEnabledStr == "True" || tagEventsEnabledStr == "TRUE" {
+		tagEventsEnabled = true
 	}
 
 	c := Config{
@@ -51,6 +59,7 @@ func NewConfig() *Config {
 		filterPattern:        os.Getenv(envFilterPattern),
 		monitoringTagKey:     monitoringTagKey,
 		monitoringTagValue:   monitoringTagValue,
+		tagEventsEnabled:     tagEventsEnabled,
 	}
 
 	err := c.validateRequired()

--- a/log-group-events-lambda/handler/config_test.go
+++ b/log-group-events-lambda/handler/config_test.go
@@ -85,6 +85,35 @@ func TestNewConfigValid(t *testing.T) {
 	assert.Equal(t, "", conf.customGroupsValue)
 	assert.Equal(t, "", conf.servicesValue)
 	assert.Equal(t, "", conf.region)
+	// Test default monitoring tag values
+	assert.Equal(t, "logzio:logs", conf.monitoringTagKey)
+	assert.Equal(t, "true", conf.monitoringTagValue)
+}
+
+func TestNewConfigWithCustomMonitoringTag(t *testing.T) {
+	InitConfigTest()
+
+	err := os.Setenv(envFirehoseArn, "test-arn")
+	assert.Nil(t, err)
+	err = os.Setenv(envAccountId, "aws-account-id")
+	assert.Nil(t, err)
+	err = os.Setenv(envAwsPartition, "test-partition")
+	assert.Nil(t, err)
+	err = os.Setenv(envMonitoringTagKey, "CustomTag")
+	assert.Nil(t, err)
+	err = os.Setenv(envMonitoringTagValue, "enabled")
+	assert.Nil(t, err)
+
+	conf := NewConfig()
+	assert.NotNil(t, conf)
+	
+	// Test custom monitoring tag values
+	assert.Equal(t, "CustomTag", conf.monitoringTagKey)
+	assert.Equal(t, "enabled", conf.monitoringTagValue)
+	
+	// Clean up
+	os.Unsetenv(envMonitoringTagKey)
+	os.Unsetenv(envMonitoringTagValue)
 }
 
 func TestValidateRequired(t *testing.T) {

--- a/log-group-events-lambda/handler/config_test.go
+++ b/log-group-events-lambda/handler/config_test.go
@@ -116,6 +116,73 @@ func TestNewConfigWithCustomMonitoringTag(t *testing.T) {
 	os.Unsetenv(envMonitoringTagValue)
 }
 
+func TestNewConfigTagEventsEnabled(t *testing.T) {
+	InitConfigTest()
+
+	tests := []struct {
+		name             string
+		envValue         string
+		expectedEnabled  bool
+	}{
+		{
+			name:            "TAG_EVENTS_ENABLED not set (default)",
+			envValue:        "",
+			expectedEnabled: false,
+		},
+		{
+			name:            "TAG_EVENTS_ENABLED set to true",
+			envValue:        "true",
+			expectedEnabled: true,
+		},
+		{
+			name:            "TAG_EVENTS_ENABLED set to True",
+			envValue:        "True",
+			expectedEnabled: true,
+		},
+		{
+			name:            "TAG_EVENTS_ENABLED set to TRUE",
+			envValue:        "TRUE",
+			expectedEnabled: true,
+		},
+		{
+			name:            "TAG_EVENTS_ENABLED set to false",
+			envValue:        "false",
+			expectedEnabled: false,
+		},
+		{
+			name:            "TAG_EVENTS_ENABLED set to invalid value",
+			envValue:        "yes",
+			expectedEnabled: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Setup required env variables
+			err := os.Setenv(envFirehoseArn, "test-arn")
+			assert.Nil(t, err)
+			err = os.Setenv(envAccountId, "aws-account-id")
+			assert.Nil(t, err)
+			err = os.Setenv(envAwsPartition, "test-partition")
+			assert.Nil(t, err)
+
+			if test.envValue != "" {
+				err = os.Setenv(envTagEventsEnabled, test.envValue)
+				assert.Nil(t, err)
+			} else {
+				os.Unsetenv(envTagEventsEnabled)
+			}
+
+			conf := NewConfig()
+			assert.NotNil(t, conf)
+			assert.Equal(t, test.expectedEnabled, conf.tagEventsEnabled)
+
+			// Clean up
+			os.Unsetenv(envTagEventsEnabled)
+		})
+	}
+}
+
 func TestValidateRequired(t *testing.T) {
 	/* Setup tests */
 	InitConfigTest()

--- a/log-group-events-lambda/handler/constants.go
+++ b/log-group-events-lambda/handler/constants.go
@@ -10,6 +10,7 @@ const (
 	envFilterPattern             = "FILTER_PATTERN"
 	envMonitoringTagKey          = "MONITORING_TAG_KEY"
 	envMonitoringTagValue        = "MONITORING_TAG_VALUE"
+	envTagEventsEnabled          = "TAG_EVENTS_ENABLED"
 
 	logzioSecretKeyName       = "logzioCustomLogGroups"
 	valuesSeparator           = ","

--- a/log-group-events-lambda/handler/constants.go
+++ b/log-group-events-lambda/handler/constants.go
@@ -8,11 +8,15 @@ const (
 	envPutSubscriptionFilterRole = "PUT_SF_ROLE"
 	envStackName                 = "STACK_NAME"
 	envFilterPattern             = "FILTER_PATTERN"
+	envMonitoringTagKey          = "MONITORING_TAG_KEY"
+	envMonitoringTagValue        = "MONITORING_TAG_VALUE"
 
-	logzioSecretKeyName    = "logzioCustomLogGroups"
-	valuesSeparator        = ","
-	emptyString            = ""
-	lambdaPrefix           = "/aws/lambda/"
-	subscriptionFilterName = "logzio_firehose"
-	maxRetries             = 10
+	logzioSecretKeyName       = "logzioCustomLogGroups"
+	valuesSeparator           = ","
+	emptyString               = ""
+	lambdaPrefix              = "/aws/lambda/"
+	subscriptionFilterName    = "logzio_firehose"
+	maxRetries                = 10
+	defaultMonitoringTagKey   = "logzio:logs"
+	defaultMonitoringTagValue = "true"
 )

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -81,7 +81,10 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 			sugLog.Errorf("`resourceArn` is not of type string or missing from EventBridge event")
 			return "", fmt.Errorf("`resourceArn` is not of type string or missing from EventBridge event 2")
 		}
-		handleTagResourceEvent(ctx, taggedResource)
+		_, err := handleTagResourceEvent(ctx, taggedResource)
+		if err != nil {
+			return "", err
+		}
 
 	case "TagResource20170331v2":
 		sugLog.Debug("Detected EventBridge TagResource20170331v2 event")
@@ -91,7 +94,10 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 			sugLog.Errorf("`resource` is not of type string or missing from EventBridge event.")
 			return "", fmt.Errorf("`resource` is not of type string or missing from EventBridge event")
 		}
-		handleTagResourceEvent(ctx, taggedResource)
+		_, err := handleTagResourceEvent(ctx, taggedResource)
+		if err != nil {
+			return "", err
+		}
 
 	case "SubscriptionFilterEvent":
 		sugLog.Debug("Detected SubscriptionFilterEvent event")

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -6,11 +6,10 @@ import (
 
 	awsArn "github.com/aws/aws-sdk-go/aws/arn"
 
-	"strings"
-
 	"github.com/logzio/firehose-logs/common"
 	"github.com/logzio/firehose-logs/logger"
 	"go.uber.org/zap"
+	"strings"
 )
 
 var sugLog *zap.SugaredLogger

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -87,7 +87,7 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 			return "", fmt.Errorf("`resource` is not of type string or missing from EventBridge event")
 		}
 		_, err := handleTagResourceEvent(ctx, taggedResource)
-		
+
 		if err != nil {
 			return "", err
 		}
@@ -117,6 +117,7 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 			sugLog.Debug("Detected unsupported Subscription Filter event")
 			return "", fmt.Errorf("unsupported Subscription Filter event")
 		}
+
 	default:
 		sugLog.Debug("Detected unsupported event")
 		return "", fmt.Errorf("unsupported event")

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -70,12 +70,24 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 		if err != nil {
 			return "", err
 		}
+
 	case "TagResource":
 		sugLog.Debug("Detected EventBridge TagResource event")
-		taggedResource, ok := requestParameters["resourceARN"].(string)
+
+		taggedResource, ok := requestParameters["resourceArn"].(string)
 		if !ok {
-			sugLog.Error("`resourceARN` is not of type string or missing from EventBridge event")
-			return "", fmt.Errorf("`resourceARN` is not of type string or missing from EventBridge event")
+			sugLog.Errorf("`resourceArn` is not of type string or missing from EventBridge event")
+			return "", fmt.Errorf("`resourceArn` is not of type string or missing from EventBridge event 2")
+		}
+		handleTagResourceEvent(ctx, taggedResource)
+
+	case "TagResource20170331v2":
+		sugLog.Debug("Detected EventBridge TagResource20170331v2 event")
+
+		taggedResource, ok := requestParameters["resource"].(string)
+		if !ok {
+			sugLog.Errorf("`resource` is not of type string or missing from EventBridge event.")
+			return "", fmt.Errorf("`resource` is not of type string or missing from EventBridge event")
 		}
 		handleTagResourceEvent(ctx, taggedResource)
 
@@ -272,7 +284,7 @@ func handleTagResourceEvent(ctx context.Context, taggedResource string) error {
 	return nil
 }
 
-func getResourceTypeFromArn(arn string) (awsResourceType, string) {
+func getResourceTypeFromArn(arn string) (awsResourceType, string) { //TODO: check aws lib arn parser
 	parts := strings.Split(arn, ":")
 	if len(parts) < 6 {
 		return Undefined, ""
@@ -299,7 +311,7 @@ func getResourceTypeFromArn(arn string) (awsResourceType, string) {
 	return Undefined, ""
 }
 
-func getLambdaLogGroupName(lambdaArn string) (string, error) {
+func getLambdaLogGroupName(lambdaArn string) (string, error) { //TODO: fetch loggroup from lambda configuration.
 	parts := strings.Split(lambdaArn, ":")
 
 	if len(parts) < 7 {

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -3,9 +3,10 @@ package handler
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	awsArn "github.com/aws/aws-sdk-go/aws/arn"
+
+	"strings"
 
 	"github.com/logzio/firehose-logs/common"
 	"github.com/logzio/firehose-logs/logger"

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -71,7 +71,7 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 		taggedResource, ok := requestParameters["resourceArn"].(string)
 		if !ok {
 			sugLog.Errorf("`resourceArn` is not of type string or missing from EventBridge event")
-			return "", fmt.Errorf("`resourceArn` is not of type string or missing from EventBridge event 2")
+			return "", fmt.Errorf("`resourceArn` is not of type string or missing from EventBridge event")
 		}
 		_, err := handleTagResourceEvent(ctx, taggedResource)
 		if err != nil {

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -16,14 +16,6 @@ import (
 var sugLog *zap.SugaredLogger
 var envConfig *Config
 
-type awsResourceType int
-
-const (
-	Undefined awsResourceType = iota
-	Lambda
-	LogGroup
-)
-
 func HandleRequest(ctx context.Context, event map[string]interface{}) (string, error) {
 	sugLog = logger.GetSugaredLogger()
 

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -116,6 +116,7 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 			sugLog.Debug("Detected unsupported Subscription Filter event")
 			return "", fmt.Errorf("unsupported Subscription Filter event")
 		}
+		
 	default:
 		sugLog.Debug("Detected unsupported event")
 		return "", fmt.Errorf("unsupported event")

--- a/log-group-events-lambda/handler/handler.go
+++ b/log-group-events-lambda/handler/handler.go
@@ -87,6 +87,7 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 			return "", fmt.Errorf("`resource` is not of type string or missing from EventBridge event")
 		}
 		_, err := handleTagResourceEvent(ctx, taggedResource)
+		
 		if err != nil {
 			return "", err
 		}
@@ -116,7 +117,6 @@ func HandleRequest(ctx context.Context, event map[string]interface{}) (string, e
 			sugLog.Debug("Detected unsupported Subscription Filter event")
 			return "", fmt.Errorf("unsupported Subscription Filter event")
 		}
-		
 	default:
 		sugLog.Debug("Detected unsupported event")
 		return "", fmt.Errorf("unsupported event")

--- a/log-group-events-lambda/handler/handler_test.go
+++ b/log-group-events-lambda/handler/handler_test.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/logzio/firehose-logs/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 func setupHandlerTest() (ctx context.Context) {
@@ -107,6 +109,234 @@ func TestUnsupportedEventHandling(t *testing.T) {
 
 			assert.NotNil(t, err)
 			assert.Equal(t, test.expectedOutputMsg, res)
+		})
+	}
+}
+
+func TestTagResourceEventHandling(t *testing.T) {
+	ctx := setupHandlerTest()
+
+	tests := []struct {
+		name              string
+		event             map[string]interface{}
+		expectedOutputMsg string
+		expectedError     bool
+	}{
+		{
+			name: "TagResource event for CloudWatch Log Group with valid ARN",
+			event: map[string]interface{}{
+				"detail": map[string]interface{}{
+					"eventName": "TagResource",
+					"requestParameters": map[string]interface{}{
+						"resourceArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/my-function",
+						"tags": map[string]interface{}{
+							"LogzIO": "True",
+						},
+					},
+				},
+			},
+			expectedOutputMsg: "TagResource event handled successfully",
+			expectedError:     false,
+		},
+		{
+			name: "TagResource event with missing resourceArn field",
+			event: map[string]interface{}{
+				"detail": map[string]interface{}{
+					"eventName": "TagResource",
+					"requestParameters": map[string]interface{}{
+						"tags": map[string]interface{}{
+							"LogzIO": "True",
+						},
+					},
+				},
+			},
+			expectedOutputMsg: "",
+			expectedError:     true,
+		},
+		{
+			name: "TagResource event with invalid ARN format",
+			event: map[string]interface{}{
+				"detail": map[string]interface{}{
+					"eventName": "TagResource",
+					"requestParameters": map[string]interface{}{
+						"resourceArn": "not-an-arn",
+						"tags": map[string]interface{}{
+							"LogzIO": "True",
+						},
+					},
+				},
+			},
+			expectedOutputMsg: "",
+			expectedError:     true,
+		},
+		{
+			name: "TagResource20170331v2 event for Lambda with valid ARN",
+			event: map[string]interface{}{
+				"detail": map[string]interface{}{
+					"eventName": "TagResource20170331v2",
+					"requestParameters": map[string]interface{}{
+						"resource": "arn:aws:lambda:us-east-1:123456789012:function:my-payment-processor",
+						"tags": map[string]interface{}{
+							"LogzIO": "True",
+						},
+					},
+				},
+			},
+			expectedOutputMsg: "TagResource20170331v2 event handled successfully",
+			expectedError:     false,
+		},
+		{
+			name: "TagResource20170331v2 event with missing resource field",
+			event: map[string]interface{}{
+				"detail": map[string]interface{}{
+					"eventName": "TagResource20170331v2",
+					"requestParameters": map[string]interface{}{
+						"tags": map[string]interface{}{
+							"LogzIO": "True",
+						},
+					},
+				},
+			},
+			expectedOutputMsg: "",
+			expectedError:     true,
+		},
+		{
+			name: "TagResource20170331v2 event with invalid Lambda ARN",
+			event: map[string]interface{}{
+				"detail": map[string]interface{}{
+					"eventName": "TagResource20170331v2",
+					"requestParameters": map[string]interface{}{
+						"resource": "invalid-lambda-arn",
+						"tags": map[string]interface{}{
+							"LogzIO": "True",
+						},
+					},
+				},
+			},
+			expectedOutputMsg: "",
+			expectedError:     true,
+		},
+		{
+			name: "TagResource event for Log Group with colon in name",
+			event: map[string]interface{}{
+				"detail": map[string]interface{}{
+					"eventName": "TagResource",
+					"requestParameters": map[string]interface{}{
+						"resourceArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/my-function:with:colons",
+						"tags": map[string]interface{}{
+							"LogzIO": "True",
+						},
+					},
+				},
+			},
+			expectedOutputMsg: "TagResource event handled successfully",
+			expectedError:     false,
+		},
+		{
+			name: "TagResource20170331v2 event for Lambda with colon in function name",
+			event: map[string]interface{}{
+				"detail": map[string]interface{}{
+					"eventName": "TagResource20170331v2",
+					"requestParameters": map[string]interface{}{
+						"resource": "arn:aws:lambda:us-east-1:123456789012:function:my-function:alias",
+						"tags": map[string]interface{}{
+							"LogzIO": "True",
+						},
+					},
+				},
+			},
+			expectedOutputMsg: "TagResource20170331v2 event handled successfully",
+			expectedError:     false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := HandleRequest(ctx, test.event)
+
+			if test.expectedError {
+				assert.NotNil(t, err)
+				assert.Equal(t, test.expectedOutputMsg, res)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.expectedOutputMsg, res)
+			}
+		})
+	}
+}
+
+func TestHandleTagResourceEvent(t *testing.T) {
+	ctx := setupHandlerTest()
+	
+	// Initialize logger and config (normally done in HandleRequest)
+	sugLog = logger.GetSugaredLogger()
+	envConfig = NewConfig()
+
+	tests := []struct {
+		name             string
+		taggedResource   string
+		expectedError    bool
+		expectedErrorMsg string
+	}{
+		{
+			name:           "Valid CloudWatch Log Group ARN",
+			taggedResource: "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/my-function",
+			expectedError:  false,
+		},
+		{
+			name:           "Valid Lambda Function ARN",
+			taggedResource: "arn:aws:lambda:us-east-1:123456789012:function:my-payment-processor",
+			expectedError:  false,
+		},
+		{
+			name:             "Invalid ARN format - not an ARN",
+			taggedResource:   "not-an-arn",
+			expectedError:    true,
+			expectedErrorMsg: "provided string is not AWS arn",
+		},
+		{
+			name:             "Invalid ARN format - missing parts",
+			taggedResource:   "arn:aws:logs",
+			expectedError:    true,
+			expectedErrorMsg: "provided string is not AWS arn",
+		},
+		{
+			name:           "Valid Log Group ARN with colons in name",
+			taggedResource: "arn:aws:logs:us-east-1:123456789012:log-group:/custom/path/with:colons:here",
+			expectedError:  false,
+		},
+		{
+			name:           "Valid Lambda ARN with alias",
+			taggedResource: "arn:aws:lambda:us-east-1:123456789012:function:my-function:prod",
+			expectedError:  false,
+		},
+		{
+			name:             "Invalid resource type - S3",
+			taggedResource:   "arn:aws:s3:::my-bucket/my-key",
+			expectedError:    true,
+			expectedErrorMsg: "unable to get name from arn.resource ",
+		},
+		{
+			name:             "Invalid resource type - EC2",
+			taggedResource:   "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+			expectedError:    true,
+			expectedErrorMsg: "unable to get name from arn.resource ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := handleTagResourceEvent(ctx, test.taggedResource)
+
+			if test.expectedError {
+				assert.NotNil(t, err)
+				if test.expectedErrorMsg != "" {
+					assert.Contains(t, err.Error(), test.expectedErrorMsg)
+				}
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, "Tag Resource Event handled successfully.", res)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description 

This PR adds support for TagResource events to automatically add subscription filters to CloudWatch log groups and Lambda functions when they are tagged.

**New Functionality:**
- Handles `TagResource` events from CloudWatch Logs (when log groups are tagged)
- Handles `TagResource20170331v2` events from AWS Lambda (when Lambda functions are tagged)
- Automatically determines the associated log group name from the resource ARN
- For Lambda functions: Converts Lambda ARN to the standard CloudWatch log group format (`/aws/lambda/{function-name}`)
- For Log Groups: Extracts the log group name directly from the ARN
- Leverages existing `handleNewLogGroupEvent` logic to apply subscription filters based on monitored services and custom prefixes

**Implementation Details:**
- Uses AWS SDK's `arn.Parse()` for robust ARN validation and parsing
- Handles edge cases like ARNs containing colons in resource names (e.g., Lambda aliases)
- Properly propagates errors from the tag resource handler to the main event handler

**Previous Behavior:** 
TagResource events were detected but not processed, requiring manual setup of subscription filters when resources were tagged.

**New Behavior:** 
When a CloudWatch log group or Lambda function is tagged, the system automatically evaluates if it matches monitored services or custom prefixes and adds subscription filters accordingly.

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes

**Test Coverage:**
- Added `TestTagResourceEventHandling` with 8 test cases covering both event types
- Added `TestHandleTagResourceEvent` with 8 unit tests for ARN parsing and validation
- Tests cover: valid ARNs, invalid ARNs, missing fields, unsupported resource types, and edge cases (ARNs with colons, aliases)
- All 85 existing tests continue to pass